### PR TITLE
minor typo in Semitone logic

### DIFF
--- a/lib/HuTrack/engine/HuTrack_parser.asm
+++ b/lib/HuTrack/engine/HuTrack_parser.asm
@@ -1368,7 +1368,7 @@ HuTrack.channel.FX.handler:
             lsr a
             tay
             lda E1XX_E2XX.table,y         ;// TODO. this is hack and needs to be fixed.
-            sta HuTrack.channel.semitoneDOWN.delta,x
+            sta HuTrack.channel.semitoneUP.delta,x
   rts
 
 ;...........................................................


### PR DESCRIPTION
Was likely copy pasted from semitonedown. Fixes to up instead of down. 